### PR TITLE
Selecting tabs in addition to the current selection

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -9,8 +9,14 @@ import { getPreferenceDict, getCommandMap, cleanDescription, isOS } from '../com
     cleanShortcutDescriptions(commandMap);
 })();
 
-browser.contextMenus.onClicked.addListener(({ menuItemId }, targetTab) => {
-    selectTabs(GetTabs[menuItemId], targetTab);
+// On macOS adding a tabel to a selection uses Command, but Ctrl on Windows.
+// Do not accept Ctrl on macOS, which is meant to open context menus.
+function holdingModifier(modifiers) {
+    return modifiers.includes("Command") || modifiers.includes("Ctrl") && !modifiers.includes("MacCtrl");
+}
+
+browser.contextMenus.onClicked.addListener(({ menuItemId, modifiers }, targetTab) => {
+    selectTabs(GetTabs[menuItemId], targetTab, holdingModifier(modifiers));
 });
 
 browser.commands.onCommand.addListener(async command => {

--- a/background/background.js
+++ b/background/background.js
@@ -9,14 +9,8 @@ import { getPreferenceDict, getCommandMap, cleanDescription, isOS } from '../com
     cleanShortcutDescriptions(commandMap);
 })();
 
-// On macOS adding a tabel to a selection uses Command, but Ctrl on Windows.
-// Do not accept Ctrl on macOS, which is meant to open context menus.
-function holdingModifier(modifiers) {
-    return modifiers.includes("Command") || modifiers.includes("Ctrl") && !modifiers.includes("MacCtrl");
-}
-
 browser.contextMenus.onClicked.addListener(({ menuItemId, modifiers }, targetTab) => {
-    selectTabs(GetTabs[menuItemId], targetTab, holdingModifier(modifiers));
+    selectTabs(GetTabs[menuItemId], targetTab, modifiers.includes("Shift"));
 });
 
 browser.commands.onCommand.addListener(async command => {

--- a/background/background.js
+++ b/background/background.js
@@ -10,7 +10,7 @@ import { getPreferenceDict, getCommandMap, cleanDescription, isOS } from '../com
 })();
 
 browser.contextMenus.onClicked.addListener(({ menuItemId, modifiers }, targetTab) => {
-    selectTabs(GetTabs[menuItemId], targetTab, modifiers.includes("Shift"));
+    selectTabs(GetTabs[menuItemId], targetTab, modifiers.includes('Shift'));
 });
 
 browser.commands.onCommand.addListener(async command => {
@@ -33,8 +33,8 @@ function buildMenu(commandMap, preferenceDict) {
 
     addRoot();
 
-    // If on MacOS, remove unsupported hotkeys
-    const format = isOS('Mac OS') ?
+    // If on MacOS, access keys are not supported so remove their markers
+    const formatTitle = isOS('Mac OS') ?
         cleanDescription :
         title => title;
 
@@ -53,6 +53,6 @@ function buildMenu(commandMap, preferenceDict) {
             currentCategory = category;
         }
 
-        addItem(id, format(title));
+        addItem(id, formatTitle(title));
     }
 }

--- a/background/select.js
+++ b/background/select.js
@@ -1,4 +1,4 @@
-export default async function selectTabs(getter, targetTab) {
+export default async function selectTabs(getter, targetTab, keepCurrent) {
     let tabsToSelect = await getter(targetTab);
 
     const getterName = getter.name;
@@ -18,6 +18,11 @@ export default async function selectTabs(getter, targetTab) {
         // Remove pinned tabs
         tabsToSelect = unpinnedIndex === -1 ?
             [] : tabsToSelect.slice(unpinnedIndex);;
+    }
+
+    if (keepCurrent === true) {
+        const currentTabs = await browser.tabs.query({ currentWindow: true, highlighted: true });
+        tabsToSelect = tabsToSelect.concat(currentTabs);
     }
 
     const tabCount = tabsToSelect.length;

--- a/background/select.js
+++ b/background/select.js
@@ -17,12 +17,12 @@ export default async function selectTabs(getter, targetTab, keepCurrent) {
     if (!includePinned) {
         // Remove pinned tabs
         tabsToSelect = unpinnedIndex === -1 ?
-            [] : tabsToSelect.slice(unpinnedIndex);;
+            [] : tabsToSelect.slice(unpinnedIndex);
     }
 
-    if (keepCurrent === true) {
-        const currentTabs = await browser.tabs.query({ currentWindow: true, highlighted: true });
-        tabsToSelect = tabsToSelect.concat(currentTabs);
+    if (keepCurrent) {
+        const currentSelectedTabs = await browser.tabs.query({ currentWindow: true, highlighted: true });
+        tabsToSelect = tabsToSelect.concat(currentSelectedTabs);
     }
 
     const tabCount = tabsToSelect.length;


### PR DESCRIPTION
Holding the modifier button that is normally used to select an additional tab (Command on macOS, Ctrl on Windows) when clicking the context menu item, the chosen selection is added to the current selection.

This would have helped me sometimes when I would have liked to select multiple different (sub-)domains in a single selection by adding “Same Site” selections. And I expect others will have more usecases. I did not see an easy way to add this for commands, so the option only affects the context menu.